### PR TITLE
fix(launcher): reset terminal state after Claude Code exits

### DIFF
--- a/claude.bat
+++ b/claude.bat
@@ -90,3 +90,8 @@ echo   Project dir:  !MCP_CODER_PROJECT_DIR!
 echo   Venv dir:     !MCP_CODER_VENV_DIR!
 
 C:\Users\%USERNAME%\.local\bin\claude.exe %*
+
+REM Reset terminal state after Claude exits (workaround for dirty terminal bug)
+REM See https://github.com/anthropics/claude-code/issues/38761
+for /f %%a in ('echo prompt $E ^| cmd') do set "ESC=%%a"
+<nul set /p="!ESC![?2004l!ESC![?1l!ESC![?25h!ESC![J"


### PR DESCRIPTION
## Summary

- Adds ANSI escape sequence reset after `claude.exe` exits in `claude.bat`
- Workaround for upstream bug [anthropics/claude-code#38761](https://github.com/anthropics/claude-code/issues/38761) where Claude Code leaves the terminal in a dirty state (broken Ctrl-C/D/L, garbage characters)
- Pure cmd.exe implementation, no PowerShell dependency

## Test plan

- [ ] Run `claude.bat`, exit with `/exit`, verify terminal controls work normally after
- [ ] Run `claude.bat`, exit with Ctrl-D, verify same
- [ ] Verify no visual artifacts or extra output after exit

🤖 Generated with [Claude Code](https://claude.com/claude-code)